### PR TITLE
Update GPIO module for Kernel 6.6 Compatibility

### DIFF
--- a/neon_phal_plugin_switches/__init__.py
+++ b/neon_phal_plugin_switches/__init__.py
@@ -148,7 +148,8 @@ class GPIOSwitches(AbstractSwitches, ABC):
                hold_time=0.5).when_activated = self.on_vol_down
 
         mute_active = True if bool(self._muted) == pull_up else False
-        self.mute_switch = Button(self.mute_pin, active_state=mute_active)
+        self.mute_switch = Button(self.mute_pin, pull_up=None,
+                                  active_state=mute_active)
 
         self.mute_switch.when_deactivated = self.on_unmute
         self.mute_switch.when_activated = self.on_mute

--- a/neon_phal_plugin_switches/__init__.py
+++ b/neon_phal_plugin_switches/__init__.py
@@ -71,7 +71,7 @@ class SwitchInputs(PHALPlugin):
             msg_type = 'mycroft.mic.unmute'
         self.bus.emit(message.reply(msg_type))
 
-    def on_button_press(self):
+    def on_button_press(self, _=None):
         LOG.info("Listen button pressed")
         if not self.switches.mute_switch.is_active:
             self.bus.emit(Message("mycroft.mic.listen"))
@@ -79,11 +79,11 @@ class SwitchInputs(PHALPlugin):
             self.bus.emit(Message("mycroft.mic.error",
                                   {"error": "mic_sw_muted"}))
 
-    def on_button_volup_press(self):
+    def on_button_volup_press(self, _=None):
         LOG.debug("VolumeUp button pressed")
         self.bus.emit(Message("mycroft.volume.increase"))
 
-    def on_button_voldown_press(self):
+    def on_button_voldown_press(self, _=None):
         LOG.debug("VolumeDown button pressed")
         self.bus.emit(Message("mycroft.volume.decrease"))
 
@@ -102,7 +102,7 @@ class GPIOSwitches(AbstractSwitches, ABC):
                  mute_callback: callable, unmute_callback: callable,
                  volup_pin: int = 22, voldown_pin: int = 23,
                  action_pin: int = 24, mute_pin: int = 25,
-                 sw_muted_state: int = 1, sw_pullup: bool = False):
+                 sw_muted_state: int = 1, sw_pullup: bool = True):
         """
         Creates an object to manage GPIO switches and callbacks on switch
         activity.
@@ -140,9 +140,12 @@ class GPIOSwitches(AbstractSwitches, ABC):
         @param pull_up: If true, pull up switches, else pull down
         """
 
-        Button(self.action_pin, pull_up=pull_up).when_activated = self.on_action
-        Button(self.vol_up_pin, pull_up=pull_up).when_activated = self.on_vol_up
-        Button(self.vol_dn_pin, pull_up=pull_up).when_activated = self.on_vol_down
+        act = Button(self.action_pin, pull_up=pull_up)
+        act.when_activated = self.on_action
+        vol_up = Button(self.vol_up_pin, pull_up=pull_up)
+        vol_up.when_activated = self.on_vol_up
+        vol_down = Button(self.vol_dn_pin, pull_up=pull_up)
+        vol_down.when_activated = self.on_vol_down
 
         mute_active = True if bool(self._muted) == pull_up else False
         self.mute_switch = Button(self.mute_pin, pull_up=None,

--- a/neon_phal_plugin_switches/__init__.py
+++ b/neon_phal_plugin_switches/__init__.py
@@ -51,7 +51,6 @@ class SwitchValidator:
 
 
 class SwitchInputs(PHALPlugin):
-    Device.pin_factory = NativeFactory()
     validator = SwitchValidator
 
     def __init__(self, bus=None, config=None):
@@ -147,17 +146,19 @@ class GPIOSwitches(AbstractSwitches, ABC):
         @param active_state: If true, switches are active when high
         """
 
-        act = Button(self.action_pin, pull_up=None, active_state=active_state)
+        act = Button(self.action_pin, pull_up=None, active_state=active_state,
+                     pin_factory=NativeFactory)
         act.when_activated = self.on_action
         vol_up = Button(self.vol_up_pin, pull_up=None,
-                        active_state=active_state)
+                        active_state=active_state, pin_factory=NativeFactory)
         vol_up.when_activated = self.on_vol_up
         vol_down = Button(self.vol_dn_pin, pull_up=None,
-                          active_state=active_state)
+                          active_state=active_state, pin_factory=NativeFactory)
         vol_down.when_activated = self.on_vol_down
 
         self.mute_switch = Button(self.mute_pin, pull_up=None,
-                                  active_state=bool(self._muted))
+                                  active_state=bool(self._muted),
+                                  pin_factory=NativeFactory)
 
         self.mute_switch.when_deactivated = self.on_unmute
         self.mute_switch.when_activated = self.on_mute

--- a/neon_phal_plugin_switches/__init__.py
+++ b/neon_phal_plugin_switches/__init__.py
@@ -148,8 +148,7 @@ class GPIOSwitches(AbstractSwitches, ABC):
                hold_time=0.5).when_activated = self.on_vol_down
 
         mute_active = True if bool(self._muted) == pull_up else False
-        self.mute_switch = Button(self.mute_pin, pull_up=pull_up, hold_time=0.5,
-                                  active_state=mute_active)
+        self.mute_switch = Button(self.mute_pin, active_state=mute_active)
 
         self.mute_switch.when_deactivated = self.on_unmute
         self.mute_switch.when_activated = self.on_mute

--- a/neon_phal_plugin_switches/__init__.py
+++ b/neon_phal_plugin_switches/__init__.py
@@ -33,15 +33,16 @@ from ovos_plugin_manager.phal import PHALPlugin
 from ovos_plugin_manager.hardware.switches import AbstractSwitches
 from ovos_utils.log import LOG
 from ovos_bus_client.message import Message
-from gpiozero import Button, pi_info, BadPinFactory, Device
+from gpiozero import Button, Device
 from gpiozero.pins.native import NativeFactory
+from gpiozero.exc import BadPinFactory
 
 
 class SwitchValidator:
     @staticmethod
     def validate(_=None):
         try:
-            pi_info()
+            Device.ensure_pin_factory()
             return True
         except BadPinFactory:
             return False
@@ -145,20 +146,20 @@ class GPIOSwitches(AbstractSwitches, ABC):
         Do GPIO setup.
         @param active_state: If true, switches are active when high
         """
-
+        factory = NativeFactory()
         act = Button(self.action_pin, pull_up=None, active_state=active_state,
-                     pin_factory=NativeFactory)
+                     pin_factory=factory)
         act.when_activated = self.on_action
         vol_up = Button(self.vol_up_pin, pull_up=None,
-                        active_state=active_state, pin_factory=NativeFactory)
+                        active_state=active_state, pin_factory=factory)
         vol_up.when_activated = self.on_vol_up
         vol_down = Button(self.vol_dn_pin, pull_up=None,
-                          active_state=active_state, pin_factory=NativeFactory)
+                          active_state=active_state, pin_factory=factory)
         vol_down.when_activated = self.on_vol_down
 
         self.mute_switch = Button(self.mute_pin, pull_up=None,
                                   active_state=bool(self._muted),
-                                  pin_factory=NativeFactory)
+                                  pin_factory=factory)
 
         self.mute_switch.when_deactivated = self.on_unmute
         self.mute_switch.when_activated = self.on_mute

--- a/neon_phal_plugin_switches/__init__.py
+++ b/neon_phal_plugin_switches/__init__.py
@@ -102,7 +102,7 @@ class GPIOSwitches(AbstractSwitches, ABC):
                  mute_callback: callable, unmute_callback: callable,
                  volup_pin: int = 22, voldown_pin: int = 23,
                  action_pin: int = 24, mute_pin: int = 25,
-                 sw_muted_state: int = 1, sw_pullup: bool = True):
+                 sw_muted_state: int = 1, sw_pullup: bool = False):
         """
         Creates an object to manage GPIO switches and callbacks on switch
         activity.
@@ -140,12 +140,9 @@ class GPIOSwitches(AbstractSwitches, ABC):
         @param pull_up: If true, pull up switches, else pull down
         """
 
-        Button(self.action_pin, pull_up=pull_up,
-               hold_time=0.5).when_activated = self.on_action
-        Button(self.vol_up_pin, pull_up=pull_up,
-               hold_time=0.5).when_activated = self.on_vol_up
-        Button(self.vol_dn_pin, pull_up=pull_up,
-               hold_time=0.5).when_activated = self.on_vol_down
+        Button(self.action_pin, pull_up=pull_up).when_activated = self.on_action
+        Button(self.vol_up_pin, pull_up=pull_up).when_activated = self.on_vol_up
+        Button(self.vol_dn_pin, pull_up=pull_up).when_activated = self.on_vol_down
 
         mute_active = True if bool(self._muted) == pull_up else False
         self.mute_switch = Button(self.mute_pin, pull_up=None,

--- a/neon_phal_plugin_switches/__init__.py
+++ b/neon_phal_plugin_switches/__init__.py
@@ -33,7 +33,8 @@ from ovos_plugin_manager.phal import PHALPlugin
 from ovos_plugin_manager.hardware.switches import AbstractSwitches
 from ovos_utils.log import LOG
 from ovos_bus_client.message import Message
-from gpiozero import Button, pi_info, BadPinFactory
+from gpiozero import Button, pi_info, BadPinFactory, Device
+from gpiozero.pins.native import NativeFactory
 
 
 class SwitchValidator:
@@ -50,6 +51,7 @@ class SwitchValidator:
 
 
 class SwitchInputs(PHALPlugin):
+    Device.pin_factory = NativeFactory()
     validator = SwitchValidator
 
     def __init__(self, bus=None, config=None):

--- a/neon_phal_plugin_switches/__init__.py
+++ b/neon_phal_plugin_switches/__init__.py
@@ -158,6 +158,10 @@ class GPIOSwitches(AbstractSwitches, ABC):
         self.mute_switch.when_deactivated = self.on_unmute
         self.mute_switch.when_activated = self.on_mute
 
+        LOG.info(f"Pin states: vol_up={vol_up.is_active}, "
+                 f"vol_down={vol_down.is_active}, act={act.is_active}, "
+                 f"mute={self.mute_switch.is_active}")
+
     @property
     def capabilities(self) -> dict:
         return {}

--- a/neon_phal_plugin_switches/__init__.py
+++ b/neon_phal_plugin_switches/__init__.py
@@ -129,6 +129,7 @@ class GPIOSwitches(AbstractSwitches, ABC):
         self.on_unmute = unmute_callback
 
         self.mute_switch: Optional[Button] = None
+        self._buttons = list()
 
         self.vol_up_pin = volup_pin
         self.vol_dn_pin = voldown_pin
@@ -159,6 +160,11 @@ class GPIOSwitches(AbstractSwitches, ABC):
         self.mute_switch.when_deactivated = self.on_unmute
         self.mute_switch.when_activated = self.on_mute
 
+        # Keep references to buttons to keep listeners alive until shutdown
+        self._buttons.append(act)
+        self._buttons.append(vol_up)
+        self._buttons.append(vol_down)
+
         LOG.info(f"Pin states: vol_up={vol_up.is_active}, "
                  f"vol_down={vol_down.is_active}, act={act.is_active}, "
                  f"mute={self.mute_switch.is_active}")
@@ -168,4 +174,6 @@ class GPIOSwitches(AbstractSwitches, ABC):
         return {}
 
     def shutdown(self):
-        pass
+        # Release GPIO buttons explicitly
+        self._buttons = None
+        self.mute_switch = None

--- a/neon_phal_plugin_switches/__init__.py
+++ b/neon_phal_plugin_switches/__init__.py
@@ -26,7 +26,6 @@
 # NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE,  EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-from os.path import exists
 from abc import ABC
 from typing import Optional
 
@@ -34,15 +33,20 @@ from ovos_plugin_manager.phal import PHALPlugin
 from ovos_plugin_manager.hardware.switches import AbstractSwitches
 from ovos_utils.log import LOG
 from ovos_bus_client.message import Message
-from sj201_interface.revisions import detect_sj201_revision
-from gpiozero import Button
+from gpiozero import Button, pi_info, BadPinFactory
 
 
 class SwitchValidator:
     @staticmethod
     def validate(_=None):
-        # TODO: More generic validation that GPIO exists
-        return detect_sj201_revision() is not None
+        try:
+            pi_info()
+            return True
+        except BadPinFactory:
+            return False
+        except Exception as e:
+            LOG.info(e)
+        return False
 
 
 class SwitchInputs(PHALPlugin):

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,4 +1,3 @@
-sj201-interface~=0.0.2
 ovos-plugin-manager~=0.0.20
 ovos-utils~=0.0.26
 ovos-bus-client~=0.0.3

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,4 +1,4 @@
 ovos-plugin-manager~=0.0.20
-ovos-utils~=0.0.26
+ovos-utils>=0.0.26, < 1.0.0
 ovos-bus-client~=0.0.3
 gpiozero~=2.0

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -2,3 +2,4 @@ sj201-interface~=0.0.2
 ovos-plugin-manager~=0.0.20
 ovos-utils~=0.0.26
 ovos-bus-client~=0.0.3
+gpiozero~=2.0


### PR DESCRIPTION
# Description
Refactor to use `gpiozero` instead of `RPi.GPIO` for Kernel 6.6 Compat.
Simplify `GPIOSwitches` class
Removes validation of `sj-201` and simply checks that gpiozero detects a device
Loosens ovos-utils dependency for future compat. with 0.1.0

# Issues
Closes #15 

# Other Notes
<!-- Note any breaking changes, WIP changes, requests for input, etc. here -->